### PR TITLE
field ( non prop ) compatibility

### DIFF
--- a/Source/MTT/ConvertMain.cs
+++ b/Source/MTT/ConvertMain.cs
@@ -264,6 +264,8 @@ namespace MSBuildTasks
 
                         string varName = modLine[1];
 
+                        if (varName.EndsWith(";")) varName = varName.Substring(0, varName.Length - 1);
+
                         LineObject obj = new LineObject()
                         {
                             VariableName = varName,


### PR DESCRIPTION
fix varname in ts when came from a field instead of a prop stripping ending semicolon

```csharp
public int myfield;
public int myprop { get; set; }
```

generates

```typescript
myfield;: number;
myprop: number;
```

insted of

```typescript
myfield: number;
myprop: number;
```