### PR TITLE
Allow hex enum values

### DIFF
--- a/Source/MTT/ConvertMain.cs
+++ b/Source/MTT/ConvertMain.cs
@@ -202,7 +202,15 @@ namespace MSBuildTasks
                                 {
                                     try
                                     {
-                                        value = Int32.Parse(modLine[2].Replace(",", ""));
+                                        var tmpValue = modLine[2].Replace(",", "");
+                                        if (tmpValue.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                                        {
+                                            value = Convert.ToInt32(tmpValue, 16);
+                                        }
+                                        else
+                                        {
+                                            value = Int32.Parse(tmpValue);
+                                        }
                                     }
                                     catch (System.Exception e)
                                     {


### PR DESCRIPTION
Added functionality so that c# enums with hex values can still be converted into typescript enum.