### PR TITLE
Update ConvertMain.cs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ artifacts/
 models/
 .dotnet/
 .vscode/
+Source/MTT/.vs/MTT/v16/Server/sqlite3/db.lock
+Source/MTT/.vs/MTT/v16/Server/sqlite3/storage.ide
+Source/MTT/.vs/MTT/v16/Server/sqlite3/storage.ide-shm
+Source/MTT/.vs/MTT/v16/Server/sqlite3/storage.ide-wal
+Source/TestConsole/Program.cs
+Source/TestConsole/TestConsole.csproj

--- a/Source/MTT/ConvertMain.cs
+++ b/Source/MTT/ConvertMain.cs
@@ -509,13 +509,15 @@ namespace MSBuildTasks
 
         private string[] ExplodeLine(string line)
         {
-            var l = line;
+            var regex = new Regex("\\s*,\\s*");
+            
+            var l = regex.Replace(line, ",");
+
             return l
                 .Replace("public", String.Empty)
                 .Replace("static", String.Empty)
                 .Replace("const", String.Empty)
                 .Replace("readonly", String.Empty)
-                .Replace(", ", String.Empty)
                 .Trim()
                 .Split(' ');
         }

--- a/Source/MTT/ConvertMain.cs
+++ b/Source/MTT/ConvertMain.cs
@@ -515,6 +515,7 @@ namespace MSBuildTasks
                 .Replace("static", String.Empty)
                 .Replace("const", String.Empty)
                 .Replace("readonly", String.Empty)
+                .Replace(", ", String.Empty)
                 .Trim()
                 .Split(' ');
         }


### PR DESCRIPTION
Fixed issue with Dictionary types such as Dictionary<string, string> not outputting the correct typescript property.  This is because the ExplodeLine method splits the line by space so it takes the latter half of the split Dictionary type as the variable name