### PR TITLE
Using Records instead of Maps

### DIFF
--- a/Source/MTT/ConvertService.cs
+++ b/Source/MTT/ConvertService.cs
@@ -349,7 +349,7 @@ namespace MTT
                             LineObject obj = new LineObject()
                             {
                                 VariableName = varName,
-                                Type = "Map",
+                                Type = "Record",
                                 IsArray = false,
                                 IsOptional = isOptional,
                                 UserDefined = false,

--- a/Source/MTT/ConvertService.cs
+++ b/Source/MTT/ConvertService.cs
@@ -597,7 +597,7 @@ namespace MTT
                                     ToCamelCase(obj.VariableName)
                                     + (obj.IsOptional ? "?" : String.Empty)
                                     + ": "
-                                    + $"{obj.Type}<{obj.Container[0].Type}, {obj.Container[1].Type}>;";
+                                    + $"Partial<{obj.Type}<{obj.Container[0].Type}, {obj.Container[1].Type}>>;";
 
                                 f.WriteLine("    " + str);
                             }

--- a/Source/MTTRunner.Tests/UnitTest.cs
+++ b/Source/MTTRunner.Tests/UnitTest.cs
@@ -98,10 +98,10 @@ namespace MTTRunner.Tests
         }
 
         [Test]
-        public void CheckMapExists() {
+        public void CheckRecordExists() {
             string[] lines = System.IO.File.ReadAllLines(VehicleFile);
 
-            Assert.That(lines[12], Is.EqualTo("    options: Map<string, Units>;"));
+            Assert.That(lines[12], Is.EqualTo("    options: Record<string, Units>;"));
         }
 
         [Test]

--- a/Source/MTTRunner.Tests/UnitTest.cs
+++ b/Source/MTTRunner.Tests/UnitTest.cs
@@ -101,7 +101,7 @@ namespace MTTRunner.Tests
         public void CheckRecordExists() {
             string[] lines = System.IO.File.ReadAllLines(VehicleFile);
 
-            Assert.That(lines[12], Is.EqualTo("    options: Record<string, Units>;"));
+            Assert.That(lines[12], Is.EqualTo("    options: Partial<Record<string, Units>>;"));
         }
 
         [Test]


### PR DESCRIPTION
Hey,
Suggest converting Dictionaries to Partial Records instead of Maps due to Records being much closer to a plain JSON object.
In the context of a DTO, when we need to use JSON.stringify (or are forced to by libraries such as MirageJS), a record is more preferable.

Seeing as Map is an object it its own right. It's expected behavior that JSON.stringify returns an empty object.
Record will serialize as expected.

```
let myMap: Map<string, string> = new Map<string, string>([["key", "value"],["key1", "value1"]]);
let myRecord: Record<string, string> = {"key": "value", "key1": "value1"};

console.log("map: " + JSON.stringify(myMap)); // [LOG]: "map: {}" 
console.log("record: " + JSON.stringify(myRecord)); // [LOG]: "record: {"key":"value","key1":"value1"}" 
```
**Note**:
Partial is to support enum keys.
```
enum myEnum {
    enumKey1,
    enumKey2
}

let m: Record<myEnum, string> = {
    [myEnum.enumKey1]: "value"
}; // Property '1' is missing in type '{ 0: string; }' but required in type 'Record<myEnum, string>'.

let partialRecord: Partial<Record<myEnum, string>> = {
    [myEnum.enumKey1]: "value"
}; // No problems :) 

console.log("partialRecord: " + JSON.stringify(partialRecord)); // [LOG]: "partialRecord: {"0":"value"}" 
```
