### PR TITLE
Supporting more complex arguments for Dictionaries

### DIFF
--- a/Example/Resources/Vehicles/Vehicle.cs
+++ b/Example/Resources/Vehicles/Vehicle.cs
@@ -29,5 +29,7 @@ namespace Example.Resources.Vehicles
         public IList<Part> SpareParts { get; set; } = new List<Part>();
 
         public Guid UserId { get; set; } 
+
+        public ReadOnlyDictionary<string, IList<Units>> UnitsListMap { get; set; }
     }
 }

--- a/Source/MTTRunner.Tests/UnitTest.cs
+++ b/Source/MTTRunner.Tests/UnitTest.cs
@@ -124,12 +124,19 @@ namespace MTTRunner.Tests
             string[] lines = System.IO.File.ReadAllLines(VehicleFile);
             Assert.That(lines[15], Is.EqualTo("    spareParts: Part[];"));
         }
-        
+
         [Test]
         public void GuidExists()
         {
             string[] lines = System.IO.File.ReadAllLines(VehicleFile);
             Assert.That(lines[16], Is.EqualTo("    userId: string;"));
+        }
+
+        [Test]
+        public void UnitListsMapExists()
+        {
+            string[] lines = System.IO.File.ReadAllLines(VehicleFile);
+            Assert.That(lines[17], Is.EqualTo("    unitsListMap: Partial<Record<string, Units[]>>;"));
         }
 
         [Test]


### PR DESCRIPTION
Adding further support for these types:
```
public ReadOnlyDictionary<string, IList<Units>> UnitsListMap { get; set; }
public Dictionary<string, Units[]> unitArrayMap { get; set; }
public ReadOnlyDictionary<string, string[]> stringArrayMap { get; set; }
```
Gets converted too
```
    unitsListMap: Partial<Record<string, Units[]>>;
    unitArrayMap: Partial<Record<string, Units[]>>;
    stringArrayMap: Partial<Record<string, string[]>>;
```

Before this change 
```public ReadOnlyDictionary<string, string[]> stringArrayMap { get; set; }```
would be incorrectly converted too
```stringArrayMap: Partial<Record<string, string>>;```