### PR TITLE
Supporting multiline Constructors

### DIFF
--- a/Example/Resources/Parts/Part.cs
+++ b/Example/Resources/Parts/Part.cs
@@ -4,6 +4,18 @@ namespace Example.Resources.Parts
 {
     public class Part: Entity
     {
+        public Part(
+            string partName,
+            string partCategory,
+            string routeNumber,
+            Units units)
+       {
+            PartName = partName;
+            PartCategory = partCategory;
+            Routenumber = routeNumber;
+            Units = units;
+       }
+
         public string PartName { get; set; }
 
         public string PartCategory { get; set; }

--- a/Example/Resources/Vehicles/Vehicle.cs
+++ b/Example/Resources/Vehicles/Vehicle.cs
@@ -11,6 +11,13 @@ namespace Example.Resources.Vehicles
 {
     public abstract class Vehicle : Entity 
     {
+        public Vehicle(int year, string make, string model) 
+        {
+            Year = year;
+            Make = make;
+            model = model;
+        }
+        
         // this is a top level comment
         public int Year { get; set; }
 

--- a/Source/MTT/ConvertService.cs
+++ b/Source/MTT/ConvertService.cs
@@ -308,7 +308,7 @@ namespace MTT
 
                             modLine = new List<string>(ExplodeLine(enumLine));
 
-                            if (IsEnumObject(enumLine))
+                            if (IsEnumObject(enumLine, file.Name))
                             {
                                 String name = modLine[0];
                                 bool isImplicit = false;
@@ -376,7 +376,7 @@ namespace MTT
                     }
 
                     // Class property
-                    if (line.StrictContains("public") && !line.StrictContains("class") && !IsContructor(line))
+                    if (line.StrictContains("public") && !line.StrictContains("class") && !IsContructor(line, file.Name))
                     {
                         string type = modLine[0];
                         /** If the property is marked virtual, skip the virtual keyword. */
@@ -799,19 +799,21 @@ namespace MTT
                 .Replace(">", String.Empty);
         }
 
-        private bool IsContructor(string line)
+        private bool IsContructor(string line, string fileName)
         {
-            return !line.StrictContains("new") && (line.Contains("()") || ((line.Contains("(") && line.Contains(")"))));
+            return (!line.StrictContains("new") && (line.Contains("()") || (line.Contains("(") && line.Contains(")")))) || 
+                line.Contains("public " + fileName + "(");
         }
 
-        private bool IsEnumObject(string line)
+
+        private bool IsEnumObject(string line, string fileName)
         {
             return 
                 !String.IsNullOrWhiteSpace(line)
                 && !line.StrictContains("enum")
                 && !line.StrictContains("namespace")
                 && !line.StrictContains("using")
-                && !IsContructor(line) 
+                && !IsContructor(line, fileName) 
                 && !line.Contains("{") && !line.Contains("}")
                 && !line.Contains("[") && !line.Contains("]");
         }


### PR DESCRIPTION
Currently MTT only supports Single Line constructor signatures
`public Vehicle(int year, string make, string model)`

This PR changes the means of identifying constructors to also entertain multiline signatures
```
public Vehicle(
    int year,
    string make,
    string model)
```

Test data is also updated to include both single and multi line constructors.